### PR TITLE
Add core(free) breach methods

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,9 @@
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in hibp.gemspec
+
+group :development, :test do
+  gem 'webmock', '~>1.24.0'
+end
+
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,53 @@
+PATH
+  remote: .
+  specs:
+    hibp (0.1.0)
+      faraday (>= 0.9.1)
+      oj (>= 3.6.13)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    diff-lcs (1.3)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
+    hashdiff (1.0.0)
+    multipart-post (2.1.1)
+    oj (3.6.13)
+    public_suffix (3.1.1)
+    rake (10.5.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.2)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.4)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.2)
+    safe_yaml (1.0.5)
+    webmock (1.24.6)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 1.17.1)
+  hibp!
+  rake (~> 10.0)
+  rspec (~> 3.0)
+  webmock (~> 1.24.0)
+
+BUNDLED WITH
+   1.17.1

--- a/hibp.gemspec
+++ b/hibp.gemspec
@@ -30,7 +30,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_dependency('faraday', '>= 0.9.1')
+  spec.add_dependency('oj', '>= 3.6.13')
+
+  spec.add_development_dependency 'bundler', '~> 1.17.1'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
 end

--- a/lib/hibp.rb
+++ b/lib/hibp.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+require 'faraday'
+require 'oj'
+
+require 'hibp/breach'
+require 'hibp/breaches/converter'
+require 'hibp/client'
+require 'hibp/parser'
+require 'hibp/request'
+require 'hibp/service_error'
+
 require 'hibp/version'
 
 module Hibp

--- a/lib/hibp/breach.rb
+++ b/lib/hibp/breach.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+module Hibp
+  # Hibp::Breach
+  #
+  #   Used to construct a "breach" model
+  #
+  #   A "breach" is an instance of a system having been compromised by an
+  #   attacker and the data disclosed.
+  #
+  #   For example, Adobe was a breach, Gawker was a breach etc.
+  #
+  class Breach
+    attr_accessor :name, :title, :domain, :description, :logo_path,
+                  :data_classes, :pwn_count,
+                  :breach_date, :added_date, :modified_date,
+                  :is_verified, :is_fabricated, :is_sensitive, :is_retired, :is_spam_list
+
+    # @param attributes [Hash] - Attributes in a hash
+    #
+    # @option attributes [String] :name  -
+    #   A name representing the breach which is unique across all other breaches.
+    #   This value never changes and may be used to name dependent assets
+    #   (such as images) but should not be shown directly to end users
+    #   (see the "title" attribute instead).
+    #
+    # @option attributes [String] :title -
+    #   A descriptive title for the breach suitable for displaying to end users.
+    #   It's unique across all breaches but individual values may change in the future
+    #   (i.e. if another breach occurs against an organisation already in the system).
+    #   If a stable value is required to reference the breach, refer to the "Name" attribute instead.
+    #
+    # @option attributes [String] :domain -
+    #   The domain of the primary website the breach occurred on.
+    #   This may be used for identifying other assets external systems may have for the site.
+    #
+    # @option attributes [Date] :breach_date -
+    #   The date (with no time) the breach originally occurred on in ISO 8601 format.
+    #   This is not always accurate — frequently breaches are discovered and reported long after the original incident.
+    #   Use this attribute as a guide only.
+    #
+    # @option attributes [DateTime] :added_date -
+    #   The date and time (precision to the minute) the breach was added to the system in ISO 8601 format.
+    #
+    # @option attributes [DateTime] :modified_date -
+    #   The date and time (precision to the minute) the breach was modified in ISO 8601 format.
+    #   This will only differ from the AddedDate attribute if other attributes
+    #   represented here are changed or data in the breach itself is changed
+    #   (i.e. additional data is identified and loaded).
+    #   It is always either equal to or greater then the AddedDate attribute, never less than.
+    #
+    # @option attributes [Integer] :pwn_count -
+    #   The total number of accounts loaded into the system.
+    #   This is usually less than the total number reported by the media due to
+    #   duplication or other data integrity issues in the source data.
+    #
+    # @option attributes [String] :description -
+    #   Contains an overview of the breach represented in HTML markup.
+    #   The description may include markup such as emphasis and strong tags as well as hyperlinks.
+    #
+    # @option attributes [Array<String>] :data_classes -
+    #   This attribute describes the nature of the data compromised in the breach and
+    #   contains an alphabetically ordered string array of impacted data classes.
+    #
+    # @option attributes [Boolean] :is_verified -
+    #   Indicates that the breach is considered unverified.
+    #   An unverified breach may not have been hacked from the indicated website.
+    #   An unverified breach is still loaded into HIBP when there's
+    #   sufficient confidence that a significant portion of the data is legitimate.
+    #
+    # @option attributes [Boolean] :is_fabricated -
+    #   Indicates that the breach is considered fabricated.
+    #   A fabricated breach is unlikely to have been hacked from the
+    #   indicated website and usually contains a large amount of manufactured data.
+    #   However, it still contains legitimate email addresses and asserts that
+    #   the account owners were compromised in the alleged breach.
+    #
+    # @option attributes [Boolean] :is_sensitive -
+    #   Indicates if the breach is considered sensitive.
+    #   The public API will not return any accounts for a breach flagged as sensitive.
+    #
+    # @option attributes [Boolean] :is_retired -
+    #   Indicates if the breach has been retired.
+    #   This data has been permanently removed and will not be returned by the API.
+    #
+    # @option attributes [Boolean] :is_spam_list -
+    #   Indicates if the breach is considered a spam list.
+    #   This flag has no impact on any other attributes but
+    #   it means that the data has not come as a result of a security compromise.
+    #
+    # @option attributes [String] :logo_path -
+    #   A URI that specifies where a logo for the breached service can be found.
+    #   Logos are always in PNG format.
+    #
+    # @raise [ArgumentError]
+    # @raise [UnknownAttributeError]
+    #
+    def initialize(attributes)
+      assign_attributes(attributes)
+    end
+
+    %i[verified fabricated sensitive retired spam_list].each do |method|
+      define_method("#{method}?") { public_send("is_#{method}") }
+    end
+
+    private
+
+    def assign_attributes(new_attributes)
+      unless new_attributes.is_a?(Hash)
+        raise ArgumentError, 'Attributes must be a Hash'
+      end
+
+      return if new_attributes.nil? || new_attributes.empty?
+
+      attributes = stringify_keys(new_attributes)
+      attributes.each { |k, v| _assign_attribute(k, v) }
+    end
+
+    def stringify_keys(hash)
+      transform_keys(hash, &:to_s)
+    end
+
+    def transform_keys(hash)
+      hash.each_with_object({}) do |(key, value), result|
+        result[yield(key)] = value
+      end
+    end
+
+    def _assign_attribute(attr_name, attr_value)
+      return unless respond_to?("#{attr_name}=")
+
+      public_send("#{attr_name}=", attr_value)
+    end
+  end
+end

--- a/lib/hibp/breaches/converter.rb
+++ b/lib/hibp/breaches/converter.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Hibp
+  module Breaches
+    # Hibp::Breaches::Converter
+    #
+    #   Used to convert raw API response data to the breach entity or
+    #     array of the entities in case if response data contains multiple breaches
+    #
+    class Converter
+      # Convert raw data to the breach entity
+      #
+      # @param data [Array<Hash>, Hash] -
+      #   Raw data that represents breach model
+      #
+      # @see https://haveibeenpwned.com/API/v3 (The breach model, Sample breach response)
+      #
+      # @return [Array<Hibp::Breach>, Hibp::Breach]
+      #
+      def convert(data)
+        data.is_a?(Array) ? convert_to_list(data) : convert_to_entity(data)
+      end
+
+      private
+
+      def convert_to_list(data)
+        data.map(&method(:convert_to_entity))
+      end
+
+      def convert_to_entity(data)
+        attributes = data.each_with_object({}) do |(key, value), hash|
+          hash[transform_key(key)] = value
+        end
+
+        ::Hibp::Breach.new(attributes)
+      end
+
+      def transform_key(key)
+        underscore(key.to_s).to_sym
+      end
+
+      def underscore(camel_cased_word)
+        camel_cased_word.gsub(/::/, '/')
+                        .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
+                        .gsub(/([a-z\d])([A-Z])/, '\1_\2')
+                        .tr('-', '_')
+                        .downcase
+      end
+    end
+  end
+end

--- a/lib/hibp/client.rb
+++ b/lib/hibp/client.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Hibp
+  # Hibp::Client
+  #
+  #   Used to fetch data from haveibeenpwned API
+  #
+  #   @see https://haveibeenpwned.com/API/v3
+  #
+  class Client
+
+    # @param api_key [String] - (optional, default: nil)
+    #   Authorisation is required for all APIs that enable searching HIBP by email address,
+    #   namely retrieving all breaches for an account and retrieving all pastes for an account.
+    #   An HIBP subscription key is required to make an authorised call and can be obtained on the API key page.
+    #   The key is then passed in a "hibp-api-key" header:
+    #
+    # @see https://haveibeenpwned.com/API/Key
+    #
+    def initialize(api_key = nil)
+      @api_key = api_key
+    end
+
+    # Find a single breached site
+    #
+    # @note This is the stable value which may or may not be the same as the breach "title" (which can change).
+    #
+    # @param name [String] - Breach name
+    #
+    # @raise [Hibp::ServiceError]
+    # @return [Hibp::Breach]
+    #
+    def find_breach(name)
+      breach_request("breach/#{name}")
+    end
+
+    # Fetch all breached sites in the system
+    #
+    # @note Collection is sorted alphabetically by the title of the breach.
+    #
+    # @param domain [String]  -
+    #   Filters the result set to only breaches against the domain specified.
+    #   It is possible that one site (and consequently domain), is compromised on multiple occasions.
+    #
+    # @raise [Hibp::ServiceError]
+    # @return [Array<Hibp::Breach>]
+    #
+    def fetch_breaches(domain = nil)
+      endpoint = domain ? "breaches?domain=#{domain}" : 'breaches'
+
+      breach_request(endpoint)
+    end
+
+    # Fetch all data classes in the system
+    #
+    # A "data class" is an attribute of a record compromised in a breach.
+    # For example, many breaches expose data classes such as "Email addresses" and "Passwords".
+    # The values returned by this service are ordered alphabetically in
+    # a string array and will expand over time as new breaches expose previously unseen classes of data.
+    #
+    # @raise [Hibp::ServiceError]
+    # @return [Array<String>]
+    #
+    def fetch_data_classes
+      Request.new(endpoint: 'dataclasses').get
+    end
+
+    private
+
+    def breach_request(endpoint)
+      parser = Parser.new(Breaches::Converter.new)
+
+      Request.new(endpoint: endpoint, parser: parser).get
+    end
+  end
+end

--- a/lib/hibp/parser.rb
+++ b/lib/hibp/parser.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Hibp
+  # Hibp::Parser
+  #
+  #   Used to parse API response and transform(convert) this
+  #     raw data to the model specified by converter
+  #
+  class Parser
+    # @param converter [Object] - (optional, default: nil)
+    #   Converter that used to convert complex
+    #   raw response data to the particular model representation.
+    #
+    #   If converter not set than parser returns raw data
+    #   (useful in cases when response returns array of strings)
+    #
+    def initialize(converter = nil)
+      @converter = converter
+    end
+
+    # Parse API response
+    #
+    # @param response []
+    #
+    # @raise [Hibp::ServiceError]
+    #
+    def parse_response(response)
+      return nil if empty_response?(response)
+
+      begin
+        _, body = prepare_response(response)
+
+        @converter ? @converter.convert(body) : body
+      rescue Oj::ParseError
+        raise_error(response.body)
+      end
+    end
+
+    private
+
+    def empty_response?(response)
+      response.body.nil? || response.body.empty?
+    end
+
+    def prepare_response(response)
+      headers = response.headers
+      body = Oj.load(response.body, symbolize_keys: true)
+
+      [headers, body]
+    end
+
+    def raise_error(payload)
+      error = ServiceError.new(
+        "Unparseable response: #{payload}",
+        title: 'UNPARSEABLE_RESPONSE', status_code: 500
+      )
+
+      raise error
+    end
+  end
+end

--- a/lib/hibp/request.rb
+++ b/lib/hibp/request.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module Hibp
+  # Hibp::Request
+  #
+  #   Used to make requests to the hibp API
+  #
+  #   @see https://haveibeenpwned.com/API/v3
+  #
+  class Request
+    API_HOST = 'https://haveibeenpwned.com/api/v3'
+
+    attr_reader :headers
+
+    # @param api_key [String] -
+    #   An HIBP subscription key is required to make an authorised call
+    #
+    # @param parser [Hibp::Parser]
+    #
+    # @param endpoint [String] -
+    #   A specific API endpoint to call appropriate method
+    #
+    def initialize(api_key: nil, parser: Parser.new, endpoint:)
+      @endpoint = endpoint
+      @parser = parser
+
+      @headers = {
+        'Content-Type' => 'application/json',
+        'User-Agent' => "Breach-Monitor-Client #{Hibp::VERSION}",
+        'hibp-api-key' => api_key
+      }
+    end
+
+    # Perform a GET request
+    #
+    # @param params [Hash]
+    # @param headers [Hash]
+    #
+    # @raise [Hibp::ServiceError]
+    #
+    def get(params: nil, headers: nil)
+      response = rest_client.get(@endpoint) do |request|
+        configure_request(request: request, params: params, headers: headers)
+      end
+
+      @parser.parse_response(response)
+    rescue StandardError => e
+      handle_error(e)
+    end
+
+    private
+
+    def rest_client
+      Faraday.new(API_HOST) do |faraday|
+        faraday.headers = @headers
+
+        faraday.response(:raise_error)
+        faraday.adapter(Faraday.default_adapter)
+      end
+    end
+
+    def configure_request(request: nil, params: nil, headers: nil, body: nil)
+      return if request.nil?
+
+      request.params.merge!(params) if params
+      request.headers.merge!(headers) if headers
+      request.body = body if body
+    end
+
+    def handle_error(error)
+      error_params = parsable_error?(error) ? parse_error(error) : {}
+
+      error_to_raise = ServiceError.new(error.message, error_params)
+
+      raise error_to_raise
+    end
+
+    def parsable_error?(error)
+      error.is_a?(Faraday::Error::ClientError) && error.response
+    end
+
+    def parse_error(error)
+      error_params = {
+        status_code: error.response[:status],
+        raw_body: error.response[:body]
+      }
+
+      begin
+        parsed_response = Oj.load(error.response[:body], {})
+
+        return error_params unless parsed_response
+
+        error_params[:body] = parsed_response
+
+        %w[title detail].each do |section|
+          next if parsed_response[section].nil?
+
+          error_params[section.to_sym] = parsed_response[section]
+        end
+      rescue Oj::ParseError
+      end
+
+      error_params
+    end
+  end
+end

--- a/lib/hibp/service_error.rb
+++ b/lib/hibp/service_error.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Hibp
+  # Hibp::ServiceError
+  #
+  #   Used to represent an error that may occur when performing a request to the API
+  #
+  class ServiceError < StandardError
+    attr_reader :correlation_id, :data, :raw_body, :status_code
+
+    # @param message [String] - (optional, '') Message to describe an error
+    # @param params [Hash] - (optional, {}) Additional error information
+    #
+    # @option params [String] :correlation_id -
+    #   A unique identifier for this particular occurrence of the problem.
+    #
+    # @option params [String] :data -
+    #   A JSON formatted error object that provides more details about the specifics of the error
+    #
+    # @option params [String] :raw_body -
+    #   Raw body from response
+    #
+    # @option params [String] :status_code  -
+    #   Http status code
+    #
+    def initialize(message = '', params = {})
+      @correlation_id = params[:correlation_id]
+      @data           = params[:data]
+      @raw_body       = params[:raw_body]
+      @status_code    = params[:status_code]
+
+      super(message)
+    end
+
+    def to_s
+      "#{super} #{instance_variables_to_s}"
+    end
+
+    private
+
+    def instance_variables_to_s
+      attr_values = %i[correlation_id data raw_body status_code].map do |attr|
+        attr_value = send(attr)
+
+        "@#{attr}=#{attr_value.inspect}"
+      end
+
+      attr_values.join(', ')
+    end
+  end
+end

--- a/spec/hibp/breach_spec.rb
+++ b/spec/hibp/breach_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Hibp::Breach do
+  describe '.new' do
+    subject { described_class.new(attributes) }
+
+    context 'when attributes are valid' do
+      let(:attributes) do
+        {
+          name: 'name',
+          title: 'title',
+          domain: 'domain',
+          description: 'description',
+          logo_path: 'logo',
+          data_classes: %w[wat so],
+          pwn_count: 1,
+          breach_date: '2019-07-22',
+          added_date: '2019-07-22',
+          modified_date: '2019-07-22',
+          is_verified: true,
+          is_fabricated: true,
+          is_sensitive: true,
+          is_retired: true,
+          is_spam_list: true
+        }
+      end
+
+      it { expect(subject.name).to eq('name') }
+
+      it { expect(subject.title).to eq('title') }
+
+      it { expect(subject.domain).to eq('domain') }
+
+      it { expect(subject.description).to eq('description') }
+
+      it { expect(subject.logo_path).to eq('logo') }
+
+      it { expect(subject.data_classes).to eq(%w[wat so]) }
+
+      it { expect(subject.pwn_count).to eq(1) }
+
+      it { expect(subject.breach_date).to eq('2019-07-22') }
+
+      it { expect(subject.added_date).to eq('2019-07-22') }
+
+      it { expect(subject.modified_date).to eq('2019-07-22') }
+
+      it { expect(subject.is_verified).to eq(true) }
+
+      it { expect(subject.is_fabricated).to eq(true) }
+
+      it { expect(subject.is_sensitive).to eq(true) }
+
+      it { expect(subject.is_retired).to eq(true) }
+
+      it { expect(subject.is_spam_list).to eq(true) }
+    end
+
+    context 'when attributes are not valid' do
+      let(:attributes) { %w[wat so] }
+
+      it { expect { subject }.to raise_error(ArgumentError) }
+    end
+  end
+
+  describe '#verified?' do
+    subject { described_class.new(is_verified: true).verified? }
+
+    it { is_expected.to be(true) }
+  end
+
+  describe '#fabricated?' do
+    subject { described_class.new(is_fabricated: true).fabricated? }
+
+    it { is_expected.to be(true) }
+  end
+
+  describe '#sensitive?' do
+    subject { described_class.new(is_sensitive: true).sensitive? }
+
+    it { is_expected.to be(true) }
+  end
+
+  describe '#retired?' do
+    subject { described_class.new(is_retired: true).retired? }
+
+    it { is_expected.to be(true) }
+  end
+
+  describe '#spam_list?' do
+    subject { described_class.new(is_spam_list: true).spam_list? }
+
+    it { is_expected.to be(true) }
+  end
+end

--- a/spec/hibp/breaches/converter_spec.rb
+++ b/spec/hibp/breaches/converter_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Hibp::Breaches::Converter do
+  describe '#convert' do
+    subject { described_class.new.convert(data) }
+
+    context 'when data is a single object' do
+      let!(:data) do
+        {
+          'Name' => 'name',
+          'Title' => 'title',
+          'Domain' => 'domain',
+          'BreachDate' => '2019-07-22',
+          'AddedDate' => '2019-07-22',
+          'ModifiedDate' => '2019-07-22',
+          'PwnCount' => 1,
+          'Description' => 'description',
+          'DataClasses' => %w[wat so],
+          'LogoPath' => 'logo'
+        }
+      end
+
+      it { is_expected.to be_an(Hibp::Breach) }
+
+      it { expect(subject.name).to eq('name') }
+
+      it { expect(subject.domain).to eq('domain') }
+
+      it { expect(subject.title).to eq('title') }
+
+      it { expect(subject.breach_date).to eq('2019-07-22') }
+
+      it { expect(subject.added_date).to eq('2019-07-22') }
+
+      it { expect(subject.modified_date).to eq('2019-07-22') }
+
+      it { expect(subject.pwn_count).to eq(1) }
+
+      it { expect(subject.description).to eq('description') }
+
+      it { expect(subject.data_classes).to eq(%w[wat so]) }
+
+      it { expect(subject.logo_path).to eq('logo') }
+    end
+
+    context 'when data is an array' do
+      let!(:data) do
+        [
+          {
+            'Name' => 'name#1',
+            'Title' => 'title#1',
+            'Domain' => 'domain#1'
+          },
+          {
+            'Name' => 'name#2',
+            'Title' => 'title#2',
+            'Domain' => 'domain#2'
+          }
+        ]
+      end
+
+      it { is_expected.to be_an(Array) }
+
+      it { expect(subject.size).to be(2) }
+
+      it { expect(subject.all? { |e| e.is_a?(Hibp::Breach) }).to be(true) }
+    end
+  end
+end

--- a/spec/hibp/client_spec.rb
+++ b/spec/hibp/client_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+RSpec.describe Hibp::Client do
+  let!(:api_host) { 'https://haveibeenpwned.com/api/v3' }
+
+  describe '#find_breach' do
+    subject { described_class.new.find_breach(name) }
+
+    let!(:name) { 'wat' }
+    let!(:data) { '{ "Name": "wat", "Title": "so" }' }
+
+    before do
+      stub_request(:get, "#{api_host}/breach/wat").to_return(body: data)
+    end
+
+    it { is_expected.to be_an(Hibp::Breach) }
+
+    it 'returns breach with parsed data' do
+      breach = subject
+
+      expect(breach.name).to eq('wat')
+      expect(breach.title).to eq('so')
+    end
+  end
+
+  describe '#fetch_breaches' do
+    subject { described_class.new.fetch_breaches }
+
+    let!(:data) { '[{ "Name": "wat", "Title": "so" }]' }
+
+    before do
+      stub_request(:get, "#{api_host}/breaches").to_return(body: data)
+    end
+
+    it { is_expected.to be_an(Array) }
+
+    it { expect(subject.size).to be(1) }
+
+    it { expect(subject.first).to be_an(Hibp::Breach) }
+
+    it 'returns breach with parsed data' do
+      breach = subject.first
+
+      expect(breach.name).to eq('wat')
+      expect(breach.title).to eq('so')
+    end
+
+    context 'when filter is set' do
+      subject { described_class.new.fetch_breaches(domain) }
+
+      let!(:domain) { 'wat' }
+
+      before do
+        stub_request(:get, "#{api_host}/breaches?domain=wat").to_return(body: data)
+      end
+
+      it { is_expected.to be_an(Array) }
+
+      it { expect(subject.size).to be(1) }
+
+      it { expect(subject.first).to be_an(Hibp::Breach) }
+    end
+  end
+
+  describe '#fetch_data_classes' do
+    subject { described_class.new.fetch_data_classes }
+
+    let!(:data) { '["wat", "so", "hey"]' }
+
+    before do
+      stub_request(:get, "#{api_host}/dataclasses").to_return(body: data)
+    end
+
+    it { expect(subject).to eq(%w[wat so hey]) }
+  end
+end

--- a/spec/hibp/parser_spec.rb
+++ b/spec/hibp/parser_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+RSpec.describe Hibp::Parser do
+  describe '#parse_response' do
+    subject { described_class.new(converter).parse_response(response) }
+
+    context 'when converter not set' do
+      let!(:converter) { nil }
+
+      context 'when response body is empty' do
+        let(:response) { double('response', body: nil, headers: nil) }
+
+        it { is_expected.to be_nil }
+      end
+
+      context 'when response body contains array of strings' do
+        let(:raw_data) { '["wat", "so", "hey"]' }
+        let(:response) { double('response', body: raw_data, headers: nil) }
+
+        it { is_expected.to eq(%w[wat so hey]) }
+      end
+
+      context 'when response body is unparseable' do
+        let(:raw_data) { 'wat response' }
+        let(:response) { double('response', body: raw_data, headers: nil) }
+
+        it { expect { subject }.to raise_error Hibp::ServiceError }
+      end
+    end
+
+    context 'when converter is set' do
+      let!(:converter) { double('converter') }
+
+      let(:raw_data)    { '["wat", "so", "hey"]' }
+      let(:parsed_data) { %w[wat so hey] }
+
+      before do
+        allow(converter).to receive(:convert).with(parsed_data).and_return('parsed!')
+      end
+
+      context 'when response body contains array of strings' do
+        let(:response) { double('response', body: raw_data, headers: nil) }
+
+        it { is_expected.to eq('parsed!') }
+      end
+    end
+  end
+end

--- a/spec/hibp/request_spec.rb
+++ b/spec/hibp/request_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Hibp::Request do
+  let(:endpoint) { 'test' }
+
+  let(:api_key)   { 'wat-key' }
+  let(:api_host)  { 'https://haveibeenpwned.com/api/v3' }
+
+  describe '#get' do
+    subject { described_class.new(api_key: api_host, endpoint: endpoint).get }
+
+    it 'surfaces client request exceptions as a Hibp::ServiceError' do
+      exception = Faraday::Error::ClientError.new('the server responded with status 500')
+
+      stub_request(:get, "#{api_host}/#{endpoint}").to_raise(exception)
+
+      expect { subject }.to raise_error(Hibp::ServiceError)
+    end
+
+    it 'surfaces an unparseable response body as a Hibp::ServiceError' do
+      response_values = { status: 503, headers: {}, body: '[foo]' }
+
+      exception = Faraday::Error::ClientError.new('the server responded with status 503', response_values)
+
+      stub_request(:get, "#{api_host}/#{endpoint}").to_raise(exception)
+
+      expect { subject }.to raise_error(Hibp::ServiceError)
+    end
+  end
+
+  describe '#handle_error' do
+    it "includes status and raw body even when json can't be parsed" do
+      response_values = { status: 503, headers: {}, body: 'A non JSON response' }
+
+      exception = Faraday::Error::ClientError.new('the server responded with status 503', response_values)
+
+      begin
+        described_class.new(api_key: api_key, endpoint: endpoint).send(:handle_error, exception)
+      rescue StandardError => boom
+        expect(boom.status_code).to eq 503
+        expect(boom.raw_body).to eq 'A non JSON response'
+      end
+    end
+  end
+end

--- a/spec/hibp/service_error_spec.rb
+++ b/spec/hibp/service_error_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Hibp::ServiceError do
+  describe '.new' do
+    context 'empty params' do
+      subject { described_class.new }
+
+      it { expect(subject.message).to eq(' @correlation_id=nil, @data=nil, @raw_body=nil, @status_code=nil') }
+
+      it { expect(subject.correlation_id).to be_nil }
+
+      it { expect(subject.data).to be_nil }
+
+      it { expect(subject.raw_body).to be_nil }
+
+      it { expect(subject.status_code).to be_nil }
+    end
+
+    context 'only message' do
+      subject { described_class.new('test message') }
+
+      it { expect(subject.message).to eq('test message @correlation_id=nil, @data=nil, @raw_body=nil, @status_code=nil') }
+
+      it { expect(subject.correlation_id).to be_nil }
+
+      it { expect(subject.data).to be_nil }
+
+      it { expect(subject.raw_body).to be_nil }
+
+      it { expect(subject.status_code).to be_nil }
+    end
+
+    context 'message and params' do
+      subject { described_class.new('test message', params) }
+
+      let(:params) do
+        {
+          correlation_id: 'correlation_id',
+          data: 'data',
+          raw_body: 'raw_body',
+          status_code: 'status_code'
+        }
+      end
+
+      it { expect(subject.message).to eq('test message @correlation_id="correlation_id", @data="data", @raw_body="raw_body", @status_code="status_code"') }
+
+      it { expect(subject.correlation_id).to eq('correlation_id') }
+
+      it { expect(subject.data).to eq('data') }
+
+      it { expect(subject.raw_body).to eq('raw_body') }
+
+      it { expect(subject.status_code).to eq('status_code') }
+    end
+  end
+
+  describe '#to_s' do
+    subject { described_class.new(message, params).to_s }
+
+    let(:message) { 'test message' }
+
+    let(:params) do
+      {
+        correlation_id: 'correlation_id',
+        data: 'data',
+        raw_body: 'raw_body',
+        status_code: 'status_code'
+      }
+    end
+
+    it { expect(subject).to eq('test message @correlation_id="correlation_id", @data="data", @raw_body="raw_body", @status_code="status_code"') }
+  end
+end

--- a/spec/hibp_spec.rb
+++ b/spec/hibp_spec.rb
@@ -4,8 +4,4 @@ RSpec.describe Hibp do
   it 'has a version number' do
     expect(Hibp::VERSION).not_to be nil
   end
-
-  it 'does something useful' do
-    expect(false).to eq(true)
-  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,10 @@
 
 require 'bundler/setup'
 require 'hibp'
+require 'webmock/rspec'
+
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+$LOAD_PATH.unshift(File.dirname(__FILE__))
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
A "breach" is an instance of a system having been compromised by an attacker and the data disclosed.
For example, Adobe was a breach, Gawker was a breach, etc.

It is possible to return the details of each breach in the system.

`Hibp::Client.new.fetch_breaches` - returns all 387(on commit date) breaches.

Also, it is possible to filter breaches by domain.

`Hibp::Client.new.fetch_breaches('adobe.com')` - Filters the result set to only breaches against the domain specified.
It is possible that one site (and consequently domain), is compromised on multiple occasions.

If just a single breach is required and this can be retrieved by the breach "name".
This is the stable value which may or may not be the same as the breach "title" (which can change).
See the breach model below for more info (https://haveibeenpwned.com/API/v3 The breach model).

`Hibp::Client.new.find_breach('000webhost')` - returns information about requested breach.

A "data class" is an attribute of a record compromised in a breach.
For example, many breaches expose data classes such as "Email addresses" and "Passwords".

`Hibp::Client.new.fetch_data_classes` - returns ordered alphabetically a string array and will
expand over time as new breaches expose previously unseen classes of data.