### PR TITLE
Add API methods that require authorization

### DIFF
--- a/lib/hibp.rb
+++ b/lib/hibp.rb
@@ -3,11 +3,20 @@
 require 'faraday'
 require 'oj'
 
+require 'hibp/attribute_assignment'
+require 'hibp/data_conversion'
+
 require 'hibp/breach'
 require 'hibp/breaches/converter'
+
 require 'hibp/client'
+
+require 'hibp/paste'
+require 'hibp/pastes/converter'
+
 require 'hibp/parser'
 require 'hibp/request'
+
 require 'hibp/service_error'
 
 require 'hibp/version'

--- a/lib/hibp/attribute_assignment.rb
+++ b/lib/hibp/attribute_assignment.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Hibp
+  # AttributeAssignment
+  #
+  #   Used to assign attributes in models
+  #
+  module AttributeAssignment
+    private
+
+    def assign_attributes(new_attributes)
+      unless new_attributes.is_a?(Hash)
+        raise ArgumentError, 'Attributes must be a Hash'
+      end
+
+      return if new_attributes.nil? || new_attributes.empty?
+
+      attributes = stringify_keys(new_attributes)
+      attributes.each { |k, v| _assign_attribute(k, v) }
+    end
+
+    def stringify_keys(hash)
+      transform_keys(hash, &:to_s)
+    end
+
+    def transform_keys(hash)
+      hash.each_with_object({}) do |(key, value), result|
+        result[yield(key)] = value
+      end
+    end
+
+    def _assign_attribute(attr_name, attr_value)
+      return unless respond_to?("#{attr_name}=")
+
+      public_send("#{attr_name}=", attr_value)
+    end
+  end
+end

--- a/lib/hibp/breach.rb
+++ b/lib/hibp/breach.rb
@@ -10,7 +10,14 @@ module Hibp
   #
   #   For example, Adobe was a breach, Gawker was a breach etc.
   #
+  #   A "breach" is an incident where data is inadvertently exposed in a vulnerable system,
+  #   usually due to insufficient access controls or security weaknesses in the software.
+  #
+  #   @see https://haveibeenpwned.com/FAQs
+  #
   class Breach
+    include Hibp::AttributeAssignment
+
     attr_accessor :name, :title, :domain, :description, :logo_path,
                   :data_classes, :pwn_count,
                   :breach_date, :added_date, :modified_date,
@@ -101,35 +108,6 @@ module Hibp
 
     %i[verified fabricated sensitive retired spam_list].each do |method|
       define_method("#{method}?") { public_send("is_#{method}") }
-    end
-
-    private
-
-    def assign_attributes(new_attributes)
-      unless new_attributes.is_a?(Hash)
-        raise ArgumentError, 'Attributes must be a Hash'
-      end
-
-      return if new_attributes.nil? || new_attributes.empty?
-
-      attributes = stringify_keys(new_attributes)
-      attributes.each { |k, v| _assign_attribute(k, v) }
-    end
-
-    def stringify_keys(hash)
-      transform_keys(hash, &:to_s)
-    end
-
-    def transform_keys(hash)
-      hash.each_with_object({}) do |(key, value), result|
-        result[yield(key)] = value
-      end
-    end
-
-    def _assign_attribute(attr_name, attr_value)
-      return unless respond_to?("#{attr_name}=")
-
-      public_send("#{attr_name}=", attr_value)
     end
   end
 end

--- a/lib/hibp/breaches/converter.rb
+++ b/lib/hibp/breaches/converter.rb
@@ -8,6 +8,8 @@ module Hibp
     #     array of the entities in case if response data contains multiple breaches
     #
     class Converter
+      include ::Hibp::DataConversion
+
       # Convert raw data to the breach entity
       #
       # @param data [Array<Hash>, Hash] -
@@ -18,33 +20,7 @@ module Hibp
       # @return [Array<Hibp::Breach>, Hibp::Breach]
       #
       def convert(data)
-        data.is_a?(Array) ? convert_to_list(data) : convert_to_entity(data)
-      end
-
-      private
-
-      def convert_to_list(data)
-        data.map(&method(:convert_to_entity))
-      end
-
-      def convert_to_entity(data)
-        attributes = data.each_with_object({}) do |(key, value), hash|
-          hash[transform_key(key)] = value
-        end
-
-        ::Hibp::Breach.new(attributes)
-      end
-
-      def transform_key(key)
-        underscore(key.to_s).to_sym
-      end
-
-      def underscore(camel_cased_word)
-        camel_cased_word.gsub(/::/, '/')
-                        .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
-                        .gsub(/([a-z\d])([A-Z])/, '\1_\2')
-                        .tr('-', '_')
-                        .downcase
+        super { |attributes| ::Hibp::Breach.new(attributes) }
       end
     end
   end

--- a/lib/hibp/data_conversion.rb
+++ b/lib/hibp/data_conversion.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Hibp
+  # Hibp::DataConversion
+  #
+  #   Used to convert raw API response data to the entity models
+  #
+  module DataConversion
+
+    protected
+
+    # Convert raw data to the entity model
+    #
+    # @param data [Array<Hash>, Hash] - Raw data from response
+    #
+    def convert(data, &block)
+      data.is_a?(Array) ? convert_to_list(data, &block) : convert_to_entity(data, &block)
+    end
+
+    private
+
+    def convert_to_list(data, &block)
+      data.map { |d| convert_to_entity(d, &block) }
+    end
+
+    def convert_to_entity(data)
+      attributes = data.each_with_object({}) do |(key, value), hash|
+        hash[transform_key(key)] = value
+      end
+
+      yield(attributes)
+    end
+
+    def transform_key(key)
+      underscore(key.to_s).to_sym
+    end
+
+    def underscore(camel_cased_word)
+      camel_cased_word.gsub(/::/, '/')
+                      .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
+                      .gsub(/([a-z\d])([A-Z])/, '\1_\2')
+                      .tr('-', '_')
+                      .downcase
+    end
+  end
+end

--- a/lib/hibp/paste.rb
+++ b/lib/hibp/paste.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Hibp
+  # Hibp::Paste
+  #
+  #   Used to construct a "paste" model
+  #
+  #   A "paste" is information that has been "pasted" to a publicly facing
+  #   website designed to share content such as Pastebin.
+  #
+  #   These services are favoured by hackers due to the ease of anonymously
+  #   sharing information and they're frequently the first place a breach appears.
+  #
+  #   @note In the future, these attributes may expand without the API being versioned.
+  #
+  #   @see https://haveibeenpwned.com/FAQs
+  #
+  class Paste
+    include ::Hibp::AttributeAssignment
+
+    attr_accessor :source, :id, :title, :date, :email_count
+
+    # @param attributes [Hash]
+    #
+    # @option attributes [String] :source -
+    #   The paste service the record was retrieved from.
+    #   Current values are:
+    #     - Pastebin
+    #     - Pastie
+    #     - Slexy
+    #     - Ghostbin
+    #     - QuickLeak
+    #     - JustPaste
+    #     - AdHocUrl
+    #     - PermanentOptOut
+    #     - OptOut
+    #
+    # @option attributes [String] :id -
+    #   The ID of the paste as it was given at the source service.
+    #   Combined with the "Source" attribute, this can be used to resolve the URL of the paste.
+    #
+    # @option attributes [String] :title -
+    #   The title of the paste as observed on the source site.
+    #   This may be null.
+    #
+    # @option attributes [String] :date -
+    #   The date and time (precision to the second) that the paste was posted.
+    #   This is taken directly from the paste site when this information is
+    #   available but may be null if no date is published.
+    #
+    # @option attributes [Integer] :email_count -
+    #   The number of emails that were found when processing the paste.
+    #   Emails are extracted by using the regular expression:
+    #   \b+(?!^.{256})[a-zA-Z0-9\.\-_\+]+@[a-zA-Z0-9\.\-_]+\.[a-zA-Z]+\b
+    #
+    def initialize(attributes)
+      assign_attributes(attributes)
+    end
+  end
+end

--- a/lib/hibp/pastes/converter.rb
+++ b/lib/hibp/pastes/converter.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Hibp
+  module Pastes
+    # Hibp::Pastes::Converter
+    #
+    #   Used to convert raw API response data to the array of the paste entities
+    #
+    class Converter
+      include ::Hibp::DataConversion
+
+      # Convert raw data to the pastes entities
+      #
+      # @param data [Array<Hash>] -
+      #   Raw data that represents pastes models
+      #
+      # @see https://haveibeenpwned.com/API/v3 (The paste model, Sample paste response)
+      #
+      # @return [Array<Hibp::Paste>]
+      #
+      def convert(data)
+        super { |attributes| ::Hibp::Paste.new(attributes) }
+      end
+    end
+  end
+end

--- a/lib/hibp/request.rb
+++ b/lib/hibp/request.rb
@@ -12,29 +12,28 @@ module Hibp
 
     attr_reader :headers
 
-    # @param api_key [String] - (optional, default: '')
-    #   An HIBP subscription key is required to make an authorised call
-    #
     # @param parser [Hibp::Parser]
     #
     # @param endpoint [String] -
     #   A specific API endpoint to call appropriate method
     #
-    def initialize(api_key: '', parser: Parser.new, endpoint:)
+    def initialize(parser: Parser.new, endpoint:)
       @endpoint = endpoint
       @parser = parser
 
       @headers = {
         'Content-Type' => 'application/json',
-        'User-Agent' => "Breach-Monitor-Client #{Hibp::VERSION}",
-        'hibp-api-key' => api_key
+        'User-Agent' => "Breach-Monitor-Client #{Hibp::VERSION}"
       }
     end
 
     # Perform a GET request
     #
-    # @param params [Hash]
-    # @param headers [Hash]
+    # @param params [Hash] -
+    #   Additional query params
+    #
+    # @param headers [Hash] -
+    #   Additional HTTP headers
     #
     # @raise [Hibp::ServiceError]
     #

--- a/spec/hibp/client_spec.rb
+++ b/spec/hibp/client_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Hibp::Client do
     end
 
     context 'when filter is set' do
-      subject { described_class.new.fetch_breaches(domain) }
+      subject { described_class.new.fetch_breaches(domain: domain) }
 
       let!(:domain) { 'wat' }
 
@@ -72,5 +72,85 @@ RSpec.describe Hibp::Client do
     end
 
     it { expect(subject).to eq(%w[wat so hey]) }
+  end
+
+  describe '#fetch_account_breaches' do
+    subject { described_class.new.fetch_account_breaches(account) }
+
+    let!(:account)  { 'wat' }
+    let!(:data)     { '[{ "Name": "wat", "Title": "so" }]' }
+
+    before do
+      stub_request(:get, "#{api_host}/breachedaccount/#{account}")
+        .to_return(body: data)
+    end
+
+    it { is_expected.to be_an(Array) }
+
+    it { expect(subject.size).to be(1) }
+
+    it { expect(subject.first).to be_an(Hibp::Breach) }
+
+    it 'returns breach with parsed data' do
+      breach = subject.first
+
+      expect(breach.name).to eq('wat')
+      expect(breach.title).to eq('so')
+    end
+
+    context 'when filters are set' do
+      context 'when domain filter is set' do
+        subject { described_class.new.fetch_account_breaches(account, domain: domain) }
+
+        let!(:domain) { 'so' }
+
+        before do
+          stub_request(:get, "#{api_host}/breachedaccount/#{account}?domain=so")
+            .to_return(body: data)
+        end
+
+        it 'returns an array of breached models' do
+          actual_models = subject
+
+          expect(actual_models).to be_an(Array)
+          expect(actual_models.size).to be(1)
+          expect(actual_models.first).to be_an(Hibp::Breach)
+        end
+      end
+
+      context 'when truncate filter is set' do
+        subject { described_class.new.fetch_account_breaches(account, truncate: true) }
+
+        before do
+          stub_request(:get, "#{api_host}/breachedaccount/#{account}?truncateResponse=true")
+            .to_return(body: data)
+        end
+
+        it 'returns an array of breached models' do
+          actual_models = subject
+
+          expect(actual_models).to be_an(Array)
+          expect(actual_models.size).to be(1)
+          expect(actual_models.first).to be_an(Hibp::Breach)
+        end
+      end
+
+      context 'when unverified filter is set' do
+        subject { described_class.new.fetch_account_breaches(account, unverified: true) }
+
+        before do
+          stub_request(:get, "#{api_host}/breachedaccount/#{account}?includeUnverified=true")
+            .to_return(body: data)
+        end
+
+        it 'returns an array of breached models' do
+          actual_models = subject
+
+          expect(actual_models).to be_an(Array)
+          expect(actual_models.size).to be(1)
+          expect(actual_models.first).to be_an(Hibp::Breach)
+        end
+      end
+    end
   end
 end

--- a/spec/hibp/paste_spec.rb
+++ b/spec/hibp/paste_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Hibp::Paste do
+  describe '.new' do
+    subject { described_class.new(attributes) }
+
+    # source, :id, :title, :date, :email_count
+    context 'when attributes are valid' do
+      let(:attributes) do
+        {
+          source: 'source',
+          id: 'identity',
+          title: 'title',
+          date: 'date',
+          email_count: 'email count'
+        }
+      end
+
+      it { expect(subject.source).to eq('source') }
+
+      it { expect(subject.id).to eq('identity') }
+
+      it { expect(subject.title).to eq('title') }
+
+      it { expect(subject.date).to eq('date') }
+
+      it { expect(subject.email_count).to eq('email count') }
+    end
+
+    context 'when attributes are not valid' do
+      let(:attributes) { %w[wat so] }
+
+      it { expect { subject }.to raise_error(ArgumentError) }
+    end
+  end
+end

--- a/spec/hibp/pastes/converter_spec.rb
+++ b/spec/hibp/pastes/converter_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Hibp::Pastes::Converter do
+  describe '#convert' do
+    subject { described_class.new.convert(data) }
+
+    let!(:data) do
+      [{
+        'Source' => 'Pastebin',
+        'Title' => 'syslog',
+        'Id' => '8Q0BvKD8',
+        'Date' => '2014-03-04T19:14:54Z',
+        'EmailCount' => '139'
+      }]
+    end
+
+    it { is_expected.to be_an(Array) }
+
+    it { expect(subject.all? { |e| e.is_a?(Hibp::Paste) }).to be(true) }
+
+    it { expect(subject.first.source).to eq('Pastebin') }
+
+    it { expect(subject.first.title).to eq('syslog') }
+
+    it { expect(subject.first.id).to eq('8Q0BvKD8') }
+
+    it { expect(subject.first.date).to eq('2014-03-04T19:14:54Z') }
+
+    it { expect(subject.first.email_count).to eq('139') }
+  end
+end

--- a/spec/hibp/request_spec.rb
+++ b/spec/hibp/request_spec.rb
@@ -3,13 +3,11 @@
 require 'spec_helper'
 
 RSpec.describe Hibp::Request do
-  let(:endpoint) { 'test' }
-
-  let(:api_key)   { 'wat-key' }
-  let(:api_host)  { 'https://haveibeenpwned.com/api/v3' }
+  let!(:endpoint)   { 'test' }
+  let!(:api_host)   { 'https://haveibeenpwned.com/api/v3' }
 
   describe '#get' do
-    subject { described_class.new(api_key: api_host, endpoint: endpoint).get }
+    subject { described_class.new(endpoint: endpoint).get }
 
     it 'surfaces client request exceptions as a Hibp::ServiceError' do
       exception = Faraday::Error::ClientError.new('the server responded with status 500')
@@ -37,7 +35,7 @@ RSpec.describe Hibp::Request do
       exception = Faraday::Error::ClientError.new('the server responded with status 503', response_values)
 
       begin
-        described_class.new(api_key: api_key, endpoint: endpoint).send(:handle_error, exception)
+        described_class.new(endpoint: endpoint).send(:handle_error, exception)
       rescue StandardError => boom
         expect(boom.status_code).to eq 503
         expect(boom.raw_body).to eq 'A non JSON response'


### PR DESCRIPTION
Added all the methods that require authorization(hibp-api-key)

Fetch a list of all breaches a particular account has been involved in.
The method takes account parameter which is the URL encoded email to be searched for.
```
client = Hibp::Client.new('api-key')

filters = {
  truncate: true,
  domain: 'abobe.com',
  unverified: true
}

client.fetch_account_breaches('example%40email.com', filters)
```

Fetch all pastes for an account
The API takes a single parameter which is the URL encoded email address to be searched for.

```
client = Hibp::Client.new('api-key')

client.fetch_account_pastes('example%40email.com')
```