### PR TITLE
Add option to add padding to password API response

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,12 @@ client.passwords('password').fetch
 
 ```
 
+You can optionally pass in a second boolean parameter to the `passwords` command, to enable response padding. This will add a random number of fake password hashes to the response, preventing anyone analysing the encrypted response from guessing the password. The fake data is removed prior to returning the array of password models so there is no additional filtering you need to do.
+```ruby
+client = Hibp::Client.new
+client.passwords('password', true).fetch
+```
+
 ### Errors
 
 This gem will throw custom exception if an API error occurred.

--- a/lib/hibp/client.rb
+++ b/lib/hibp/client.rb
@@ -125,7 +125,7 @@ module Hibp
     #
     # @return [Hibp::Query]
     #
-    def passwords(password, add_padding=false)
+    def passwords(password, add_padding: false)
       configure_password_query(password, add_padding)
     end
 

--- a/lib/hibp/client.rb
+++ b/lib/hibp/client.rb
@@ -114,23 +114,29 @@ module Hibp
     # @param password [String] -
     #   The value of the source password being searched for
     #
+    # @param add_padding [Boolean] -
+    #   Pads out the response with a random number of fake requests, to prevent
+    #   anyone looking at the responses from guessing what the hash prefix was.
+    #   
+    #
     # @note The API will respond with include the suffix of every hash beginning
     #       with the specified password prefix(five first chars of the password hash),
     #       and with a count of how many times it appears in the data set.
     #
     # @return [Hibp::Query]
     #
-    def passwords(password)
-      configure_password_query(password)
+    def passwords(password, add_padding=false)
+      configure_password_query(password, add_padding)
     end
 
     private
 
-    def configure_password_query(password)
+    def configure_password_query(password, add_padding)
       pwd_hash = ::Digest::SHA1.hexdigest(password).upcase
       endpoint = "#{PASSWORD_API_HOST}/#{pwd_hash[0..4]}"
+      headers = add_padding ? {'Add-Padding' => 'true'} : {}
 
-      Query.new(endpoint: endpoint, parser: Parsers::Password.new)
+      Query.new(endpoint: endpoint, headers: headers, parser: Parsers::Password.new)
     end
 
     def configure_core_query(service, parameter = nil)

--- a/lib/hibp/parsers/password.rb
+++ b/lib/hibp/parsers/password.rb
@@ -10,7 +10,8 @@ module Hibp
       ROWS_SPLITTER = "\r\n"
       ATTRIBUTES_SPLITTER = ':'
 
-      # Convert API response raw data to the passwords models.
+      # Convert API response raw data to the passwords models. If occurrences of
+      # a hash suffix are 0 then it's fake data added by the add_padding option
       #
       # @param response [] -
       #   Contains the suffix of every hash beginning with the specified prefix,
@@ -21,15 +22,15 @@ module Hibp
       def parse_response(response)
         data = response.body
 
-        data.split(ROWS_SPLITTER).map(&method(:convert_to_password))
-      end
+        data.split(ROWS_SPLITTER).inject([]) do |array, row|
+          suffix, occurrences = row.split(ATTRIBUTES_SPLITTER)
 
-      private
+          if occurrences.to_i > 0
+            array <<  Models::Password.new(suffix: suffix, occurrences: occurrences.to_i)
+          end
 
-      def convert_to_password(row)
-        suffix, occurrences = row.split(ATTRIBUTES_SPLITTER)
-
-        Models::Password.new(suffix: suffix, occurrences: occurrences.to_i)
+          array
+        end
       end
     end
   end

--- a/spec/hibp/client_spec.rb
+++ b/spec/hibp/client_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Hibp::Client do
 
   describe '#passwords' do
     let(:add_padding) { false }
-    subject { described_class.new.passwords('test', add_padding) }
+    subject { described_class.new.passwords('test', add_padding: add_padding) }
 
     it { is_expected.to be_an(Hibp::Query) }
 

--- a/spec/hibp/client_spec.rb
+++ b/spec/hibp/client_spec.rb
@@ -58,12 +58,21 @@ RSpec.describe Hibp::Client do
   end
 
   describe '#passwords' do
-    subject { described_class.new.passwords('test') }
+    let(:add_padding) { false }
+    subject { described_class.new.passwords('test', add_padding) }
 
     it { is_expected.to be_an(Hibp::Query) }
 
     it { expect(subject.endpoint).to eq('https://api.pwnedpasswords.com/range/A94A8') }
 
-    it { expect(subject.headers).to eq({}) }
+    context 'when add_padding is true' do
+      let(:add_padding) { true }
+
+      it { expect(subject.headers).to eq({'Add-Padding' => 'true'}) }
+    end
+
+    context 'when add_padding is false' do
+      it { expect(subject.headers).to eq({}) }
+    end
   end
 end

--- a/spec/hibp/parsers/password_spec.rb
+++ b/spec/hibp/parsers/password_spec.rb
@@ -33,10 +33,10 @@ RSpec.describe Hibp::Parsers::Password do
         it 'does not convert them into password models' do
           actual_passwords = subject
 
-          occurrences = actual_passwords.map(&:occurrences)
+          suffixes = actual_passwords.map(&:suffix)
 
           expect(actual_passwords.count).to eq(2)
-          expect(occurrences).not_to include('003D68EB55068C33ACE09247EE4C639306B')
+          expect(suffixes).not_to include('003D68EB55068C33ACE09247EE4C639306B')
         end
       end
     end

--- a/spec/hibp/parsers/password_spec.rb
+++ b/spec/hibp/parsers/password_spec.rb
@@ -24,6 +24,21 @@ RSpec.describe Hibp::Parsers::Password do
         expect(suffixes).to eq(%w[0018A45C4D1DEF81644B54AB7F969B88D65 00D4F6E8FA6EECAD2A3AA415EEC418D38EC])
         expect(occurrences).to eq([1, 2])
       end
+
+      context 'when there are passwords with 0 occurrences' do
+        let(:body) do
+          "0018A45C41DEF81644B54AB7F969B88D65:1\r\n00D4F6E8FA6EECAD2A3AA415EEC418D38EC:2\r\n003D68EB55068C33ACE09247EE4C639306B:0"
+        end
+
+        it 'does not convert them into password models' do
+          actual_passwords = subject
+
+          occurrences = actual_passwords.map(&:occurrences)
+
+          expect(actual_passwords.count).to eq(2)
+          expect(occurrences).not_to include('003D68EB55068C33ACE09247EE4C639306B')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
HIBP has the option to [enable padding to the password responses](https://haveibeenpwned.com/API/v3#PwnedPasswordsPadding) to prevent any analysing the traffic from guessing the password hash based on response size. This PR adds an extra option to the `Hibp::Client#passwords` command to enable it.